### PR TITLE
Update .gitmodules due to GitHub security change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests"]
 	path = tests
-	url = git://github.com/editorconfig/editorconfig-core-test.git
+	url = https://github.com/editorconfig/editorconfig-core-test.git


### PR DESCRIPTION
GitHub no longer allows unencrypted git connections. See https://github.blog/2021-09-01-improving-git-protocol-security-github/

Without this change, it causes the following error when trying to clone the sub-repository:-
```
Cloning into '/home/chaz/git/github.com_dail8859_NotepadNext/src/editorconfig-core-qt/tests'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```