### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,17 @@ project(editorconfig-core-qt
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+find_package(Qt6 COMPONENTS Core)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Core)
+endif()
 
 add_library(editorconfig-core-qt
     EditorConfig.cpp
     EditorConfig.h
 )
 
-target_link_libraries(editorconfig-core-qt PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+target_link_libraries(editorconfig-core-qt PRIVATE Qt::Core)
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )
 
@@ -25,7 +27,7 @@ option(BUILD_EDITORCONFIG_CMD "Build executable to run EditorConfig tests" OFF)
 
 if (BUILD_EDITORCONFIG_CMD)
     add_executable(editorconfig-app src/editorconfig-app/main.cpp)
-    target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt${QT_VERSION_MAJOR}::Core)
+    target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt::Core)
 
     enable_testing()
     set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/editorconfig-app.exe)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,15 @@
-project(editorconfig-core-qt)
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
+project(editorconfig-core-qt
+        VERSION 0.0.1
+        DESCRIPTION "EditorConfig Qt5/6 core bindings"
+        LANGUAGES CXX
+)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Gui Network REQUIRED)
+find_package(Qt5 COMPONENTS Core REQUIRED)
 
 enable_testing()
 set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/src/editorconfig-app/editorconfig-app)
@@ -30,7 +31,6 @@ endif()
 target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Core )
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )
-
 
 add_executable(editorconfig-app src/editorconfig-app/main.cpp)
 target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt5::Core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,24 @@
-# This file is used for testing only
+project(editorconfig-core-qt)
+cmake_minimum_required(VERSION 3.20)
 
-# To perform the test, run `cmake .` at the root of the project tree followed
-# by ctest .
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
 
-cmake_minimum_required(VERSION 2.6)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Do not check any compiler
-project(editorconfig-core-qt NONE)
+find_package(Qt5 COMPONENTS Core Gui Network Widgets REQUIRED)
 
-enable_testing()
+#enable_testing()
 set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/editorconfig-app.exe)
-add_subdirectory(tests)
+#add_subdirectory(tests)
+
+add_library(editorconfig-core-qt
+    EditorConfig.cpp
+    EditorConfig.h
+)
+target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Widgets )
+target_include_directories(editorconfig-core-qt PUBLIC . )
+target_include_directories(editorconfig-core-qt PRIVATE . )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
+include(GenerateExportHeader)
+
 project(editorconfig-core-qt
         VERSION 0.0.1
         DESCRIPTION "EditorConfig Qt5/6 core bindings"
@@ -19,9 +21,21 @@ add_library(editorconfig-core-qt
     EditorConfig.h
 )
 
-target_link_libraries(editorconfig-core-qt PRIVATE Qt::Core)
-target_include_directories(editorconfig-core-qt PUBLIC . )
-target_include_directories(editorconfig-core-qt PRIVATE . )
+target_link_libraries(editorconfig-core-qt
+  PRIVATE
+    Qt::Core
+)
+
+target_include_directories(editorconfig-core-qt
+  PUBLIC
+    .
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+generate_export_header(editorconfig-core-qt
+  EXPORT_FILE_NAME
+    editorconfig-core-qt-export.h
+)
 
 option(BUILD_EDITORCONFIG_CMD "Build executable to run EditorConfig tests" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,11 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Gui Network Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui Network REQUIRED)
 
-#enable_testing()
-set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/editorconfig-app.exe)
-#add_subdirectory(tests)
+enable_testing()
+set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/src/editorconfig-app/editorconfig-app)
+add_subdirectory(tests)
 
 if (BUILD_STATIC)
     set(CMAKE_STATIC_LIBRARY_SUFFIX "_static${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -27,7 +27,10 @@ else()
     )
 endif()
 
-target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Widgets )
+target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Core )
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )
 
+
+add_executable(editorconfig-app src/editorconfig-app/main.cpp)
+target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt5::Core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.20)
 include(GenerateExportHeader)
 
 project(editorconfig-core-qt
-        VERSION 0.0.1
-        DESCRIPTION "EditorConfig Qt5/6 core bindings"
-        LANGUAGES CXX
+    VERSION 0.0.1
+    DESCRIPTION "EditorConfig Qt5/6 core bindings"
+    LANGUAGES CXX
 )
 
 set(CMAKE_CXX_STANDARD 17)
@@ -22,24 +22,24 @@ add_library(editorconfig-core-qt
 )
 
 target_link_libraries(editorconfig-core-qt
-  PRIVATE
+    PRIVATE
     Qt::Core
 )
 
 target_include_directories(editorconfig-core-qt
-  PUBLIC
+    PUBLIC
     .
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 generate_export_header(editorconfig-core-qt
-  EXPORT_FILE_NAME
+    EXPORT_FILE_NAME
     editorconfig-core-qt-export.h
 )
 
-option(BUILD_EDITORCONFIG_CMD "Build executable to run EditorConfig tests" OFF)
+option(EDITORCONFIG_QT_BUILD_CMD "Build executable to run EditorConfig tests" OFF)
 
-if (BUILD_EDITORCONFIG_CMD)
+if (EDITORCONFIG_QT_BUILD_CMD)
     add_executable(editorconfig-app src/editorconfig-app/main.cpp)
     target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt::Core)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,19 @@ find_package(Qt5 COMPONENTS Core Gui Network Widgets REQUIRED)
 set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/editorconfig-app.exe)
 #add_subdirectory(tests)
 
-add_library(editorconfig-core-qt
-    EditorConfig.cpp
-    EditorConfig.h
-)
+if (BUILD_STATIC)
+    set(CMAKE_STATIC_LIBRARY_SUFFIX "_static${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    add_library(editorconfig-core-qt STATIC
+        EditorConfig.cpp
+        EditorConfig.h
+    )
+else()
+    add_library(editorconfig-core-qt SHARED
+        EditorConfig.cpp
+        EditorConfig.h
+    )
+endif()
+
 target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Widgets )
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,29 +9,25 @@ project(editorconfig-core-qt
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 
-enable_testing()
-set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/src/editorconfig-app/editorconfig-app)
-add_subdirectory(tests)
+add_library(editorconfig-core-qt
+    EditorConfig.cpp
+    EditorConfig.h
+)
 
-if (BUILD_STATIC)
-    set(CMAKE_STATIC_LIBRARY_SUFFIX "_static${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    add_library(editorconfig-core-qt STATIC
-        EditorConfig.cpp
-        EditorConfig.h
-    )
-else()
-    add_library(editorconfig-core-qt SHARED
-        EditorConfig.cpp
-        EditorConfig.h
-    )
-endif()
-
-target_link_libraries(editorconfig-core-qt PRIVATE Qt::Core)
+target_link_libraries(editorconfig-core-qt PRIVATE Qt${QT_VERSION_MAJOR}::Core)
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )
 
-add_executable(editorconfig-app src/editorconfig-app/main.cpp)
-target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt::Core)
+option(BUILD_EDITORCONFIG_CMD "Build executable to run EditorConfig tests" OFF)
+
+if (BUILD_EDITORCONFIG_CMD)
+    add_executable(editorconfig-app src/editorconfig-app/main.cpp)
+    target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt${QT_VERSION_MAJOR}::Core)
+
+    enable_testing()
+    set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/editorconfig-app.exe)
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ project(editorconfig-core-qt
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 
 enable_testing()
 set(EDITORCONFIG_CMD ${CMAKE_BINARY_DIR}/src/editorconfig-app/editorconfig-app)
@@ -28,9 +29,9 @@ else()
     )
 endif()
 
-target_link_libraries(editorconfig-core-qt PRIVATE Qt5::Core )
+target_link_libraries(editorconfig-core-qt PRIVATE Qt::Core)
 target_include_directories(editorconfig-core-qt PUBLIC . )
 target_include_directories(editorconfig-core-qt PRIVATE . )
 
 add_executable(editorconfig-app src/editorconfig-app/main.cpp)
-target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt5::Core)
+target_link_libraries(editorconfig-app PRIVATE editorconfig-core-qt Qt::Core)

--- a/EditorConfig.h
+++ b/EditorConfig.h
@@ -27,11 +27,12 @@
 
 #include <QString>
 #include <QMap>
+#include "editorconfig-core-qt-export.h"
 
 
 typedef QMap<QString, QString> EditorConfigSettings;
 
-class EditorConfig
+class EDITORCONFIG_CORE_QT_EXPORT EditorConfig
 {
 public:
     static EditorConfigSettings getFileSettings(const QString &filePath, const QString &configName = ".editorconfig");

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ editors which allow this file format to be read and used by those editors.  For
 information on the file format and supported text editors, see the
 [EditorConfig website](http://editorconfig.org).
 
-## How to use EditorConfig Qt5 Core
+## How to use EditorConfig Qt5 Core (QMake)
 
 To include the library files it is recommend that you add it as a git submodule to your project.
 
@@ -35,6 +35,18 @@ for(auto setting : settings.toStdMap()) {
     std::cout << qUtf8Printable(setting.first) << "=" << qUtf8Printable(setting.second) << std::endl;
 }
 ```
+
+## How to use EditorConfig Qt5 Core (Cmake)
+
+The easiest way, should be to use CPM (https://github.com/cpm-cmake/CPM.cmake). Then,
+inside your application do:
+
+``` CMake
+# Or any other sha1 you want.
+CPMAddPackage("gh:editorconfig/editorconfig-core-qt#master")
+```
+
+The follow instructions for QMake for code integration.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,5 @@ This has been developed with Qt 5.15+ however previous versions *may* work. To d
 1. Open `CMakeLists.txt` with Qt Creator
 1. Configure the project and set `BUILD_EDITORCONFIG_CMD` to `ON`
 1. Build the project
-1. Using (cmd|powershell), navigate to the output directory
-1. Execute `ctest`
+1. If ctests is configured for Qt Creator, it will run the tests
 1. The majority of tests should pass

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EditorConfig Qt5 Core
+# EditorConfig Qt Core
 
-EditorConfig Qt5 core bindings. Does not require any external dependencies.
+EditorConfig core bindings for Qt5 and Qt6. Does not require any external dependencies.
 
 ## EditorConfig Project
 
@@ -11,7 +11,11 @@ editors which allow this file format to be read and used by those editors.  For
 information on the file format and supported text editors, see the
 [EditorConfig website](http://editorconfig.org).
 
-## How to use EditorConfig Qt5 Core (QMake)
+## Build Tool Integration
+
+This project can be built and used with both qmake and cmake.
+
+### QMake
 
 To include the library files it is recommend that you add it as a git submodule to your project.
 
@@ -25,10 +29,25 @@ Then include the `EditorConfig.pri` file in your .pro project file.
 include(editorconfig-core-qt/EditorConfig.pri)
 ```
 
-It can then be used within your Qt application.
+### CMake
+
+The easiest way should be to use CPM (https://github.com/cpm-cmake/CPM.cmake). Then,
+inside your CMake project do:
+
+```CMake
+# Or any other sha1 you want.
+CPMAddPackage("gh:editorconfig/editorconfig-core-qt#master")
+```
+
+You can alternatively add it as a git submodule and manually use `add_subdirectory()` to add the `CMakeLists.txt` file in your project.
+
+## Usage
+Once built, the library can then be used within your Qt application.
 
 ```c++
 #include <EditorConfig>
+
+...
 
 EditorConfigSettings settings = EditorConfig::getFileSettings("path/to/myfile.txt");
 for(auto setting : settings.toStdMap()) {
@@ -36,25 +55,13 @@ for(auto setting : settings.toStdMap()) {
 }
 ```
 
-## How to use EditorConfig Qt5 Core (CMake)
-
-The easiest way, should be to use CPM (https://github.com/cpm-cmake/CPM.cmake). Then,
-inside your application do:
-
-``` CMake
-# Or any other sha1 you want.
-CPMAddPackage("gh:editorconfig/editorconfig-core-qt#master")
-```
-
-The follow instructions for QMake for code integration.
-
 ## Development
 
-This has been developed with Qt 5.14, however previous versions *may* work. This has only been tested on Windows.
+This has been developed with Qt 5.15+ however previous versions *may* work. To develop/test this module you can use the following instructions:
 
-1. Open `src/editorconfig-app/editorconfig-app.pro` with Qt Creator
-1. Build the release version (this will place the exe in a `build` directory in the root of this source code repository)
-1. Using (cmd|powershell), navigate to the `build` directory
-1. Execute `cmake ..`
-1. Execute `ctest -C Release` (no clue why it needs the `-C Release`)
+1. Open `CMakeLists.txt` with Qt Creator
+1. Configure the project and set `BUILD_EDITORCONFIG_CMD` to `ON`
+1. Build the project
+1. Using (cmd|powershell), navigate to the output directory
+1. Execute `ctest`
 1. The majority of tests should pass

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ for(auto setting : settings.toStdMap()) {
 }
 ```
 
-## How to use EditorConfig Qt5 Core (Cmake)
+## How to use EditorConfig Qt5 Core (CMake)
 
 The easiest way, should be to use CPM (https://github.com/cpm-cmake/CPM.cmake). Then,
 inside your application do:


### PR DESCRIPTION
This PR adds `CMake` support for the library. The best way I know to integrate this is using `CPM` which is documented.

I am using this as part of my port of NotepadNext to CMake (https://github.com/elcuco/NotepadNext/tree/cmake-build). 

Unit tests are failing, the same as they are failing on `qmake` on my setup - so I did not break anything new (I hope...).

I can squash the commits if needed (this should make the history cleaner for the main project).
